### PR TITLE
Enable Github Actions to automatically run tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8
+    - name: Check formatting with black
+      run: |
+        pip install black
+        black --check .
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/hypnotoad2/test_suite/test_torpex.py
+++ b/hypnotoad2/test_suite/test_torpex.py
@@ -55,7 +55,7 @@ class TestTORPEX:
         R = numpy.linspace(Rmin, Rmax, nR)[numpy.newaxis, :]
         Z = numpy.linspace(Zmin, Zmax, nZ)[:, numpy.newaxis]
 
-        assert equilib.psi(R, Z) == pytest.approx(grid_equilib.psi(R, Z), rel=1.0e-10)
+        assert equilib.psi(R, Z) == pytest.approx(grid_equilib.psi(R, Z), rel=1.0e-9)
 
         import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 options 
 PyYAML
 scipy>=1.3.0
+boututils


### PR DESCRIPTION
Requires tidying up `torpex.py` to remove uses of `pyEquilibrium.geqdsk` or `boututils.geqdsk`.

`boututils` is required in various places, so added to `requirements.txt`.