### PR TITLE
Add install requirements to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-options 
-PyYAML
-scipy>=1.3.0
-boututils
+# the following line installs requirements from setup.py
+-e .

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
+        "boututils~=0.1.4",
         "matplotlib~=3.2",
         "netCDF4~=1.5",
         "numpy~=1.18",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,15 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
+    install_requires=[
+        "matplotlib~=3.2",
+        "netCDF4~=1.5",
+        "numpy~=1.18",
+        "options~=1.4",
+        "pyparsing~=2.4",
+        "PyYAML~=5.3",
+        "scipy~=1.4",
+    ],
     python_requires=">=3.6",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Allows pip to install all dependencies. I installed from `requirements.txt`, then the other needed and optional modules, and then did `pip freeze`. I used `~=` to get the latest patch version for the corresponding minor version.