### PR TITLE
Fix version identifier for a release which does not have the git repo

### DIFF
--- a/hypnotoad2/__version__.py
+++ b/hypnotoad2/__version__.py
@@ -1,1 +1,2 @@
 __version__ = "0.1.0"
+__release__ = False


### PR DESCRIPTION
hypnotoad2 saved a `hypnotoad_git_hash` variable into the output files. This will not work for a released version distributed on PyPi whose source code is not installed in the git repo. Replace with `hypnotoad_version` which is the git hash when hypnotoad is in a cloned git repo, or __version__.__version__ for a release version. Released versions must have _version__.__release__ set to True to enable this.